### PR TITLE
attempt to fix cors issue

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -8,9 +8,9 @@ server {
   location / {
     root   /usr/share/nginx/html;
     index cbiSponsorships.json;
-
+    
+    add_header Access-Control-Allow-Origin "*";
     if ($request_method = OPTIONS ) {
-      add_header Access-Control-Allow-Origin "*";
       add_header Access-Control-Expose-Headers "Etag,Link,Content-Type";
       add_header Access-Control-Allow-Methods "GET, OPTIONS";
       add_header Access-Control-Allow-Headers "Authorization,content-type";


### PR DESCRIPTION
With the latest changes, we now have a different error:

Access to fetch at 'https://api.eclipse.org/cbi/sponsorships' from origin 'https://membership-staging.eclipse.org' has been blocked by CORS policy: No 'Access-Control-Allow-Origin' header is present on the requested resource. If an opaque response serves your needs, set the request's mode to 'no-cors' to fetch the resource with CORS disabled.